### PR TITLE
Fix bug: fix path in clone setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The backend uses Flask and the `linkedin-api` library to interact with LinkedIn,
 
    ```bash
    git clone https://github.com/Namit2111/Linkedin-to-resume
-   cd backend
+   cd Linkedin-to-resume/backend
    ```
 
 2. **Create a virtual environment**:


### PR DESCRIPTION
There's a really minor issue in the documentation for setting up the documentation that can be fixed.

![image](https://github.com/user-attachments/assets/12fd09b7-51f1-4348-8f09-0db1056ec0d6)

This is sorta incorrect as the user first needs to cd into the Linkedin-to-resume project folder and then cd into the backend folder, as the cli does not open the file by default while cloning.

![image](https://github.com/user-attachments/assets/f596ded0-5396-4ed1-a9a8-fb7fdbf540f9)


Correct Instruction Should be:

```
git clone https://github.com/Namit2111/Linkedin-to-resume
cd Linkedin-to-resume/backend
```

Which is fixed in this PR. 